### PR TITLE
feat: add support for excluding paths in user agent filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ config = GuardConfig(
     user_agent={
         "enabled": True,
         "blocked_agents": ["curl", "wget", "Scrapy", "bot", "Bot"],
+        "excluded_paths": ["/ready", "/healthz"]
     },
     cors={
         "enabled": True,

--- a/docs/core/config.md
+++ b/docs/core/config.md
@@ -18,7 +18,7 @@ config = GuardConfig()
 config = GuardConfig(
     ip_filter={"whitelist": ["127.0.0.1"]},
     rate_limit={"requests_per_minute": 100},
-    user_agent={"blocked_agents": ["curl", "wget"]}
+    user_agent={"blocked_agents": ["curl", "wget"], "excluded_paths": ["/ready", "/healthz"]}
 )
 ```
 
@@ -114,13 +114,15 @@ from pywebguard.core.config import UserAgentConfig
 # Create user agent configuration
 user_agent = UserAgentConfig(
     enabled=True,
-    blocked_agents=["curl", "wget", "python-requests"]
+    blocked_agents=["curl", "wget", "python-requests"],
+    excluded_paths= ["/ready", "/healthz"]
 )
 
 # Or as a dictionary
 user_agent_dict = {
     "enabled": True,
-    "blocked_agents": ["curl", "wget", "python-requests"]
+    "blocked_agents": ["curl", "wget", "python-requests"],
+     "excluded_paths": ["/ready", "/healthz"]
 }
 ```
 
@@ -128,6 +130,8 @@ user_agent_dict = {
 
 - `enabled`: Whether user agent filtering is enabled (default: `True`)
 - `blocked_agents`: List of blocked user agent strings (default: `[]`)
+- `excluded_paths`: List of endpoint paths where user-agent filtering should be bypassed.
+        Useful for allowing monitoring tools to access health check endpoints like '/ready' or '/healthz'. (default: `[]`)
 
 ## Penetration Detection Configuration
 
@@ -299,7 +303,8 @@ config = GuardConfig(
     },
     user_agent={
         "enabled": True,
-        "blocked_agents": ["curl", "wget", "python-requests"]
+        "blocked_agents": ["curl", "wget", "python-requests"],
+         "excluded_paths": ["/ready"]
     },
     penetration={
         "enabled": True,

--- a/pywebguard/core/base.py
+++ b/pywebguard/core/base.py
@@ -347,7 +347,9 @@ class Guard:
             }
 
         # Check user agent filter
-        ua_result = self.user_agent_filter.is_allowed(request_info["user_agent"])
+        ua_result = self.user_agent_filter.is_allowed(
+            request_info["user_agent"], request_info["path"]
+        )
         if not ua_result["allowed"]:
             self.logger.log_blocked_request(
                 request_info, "User agent filter", ua_result["reason"]

--- a/pywebguard/core/config.py
+++ b/pywebguard/core/config.py
@@ -76,15 +76,19 @@ class RateLimitConfig(BaseModel):
 
 
 class UserAgentConfig(BaseModel):
-    """Configuration for user agent filtering.
+    """
+    Configuration for user-agent filtering.
 
     Attributes:
-        enabled: Whether user agent filtering is enabled
-        blocked_agents: List of blocked user agent strings
+        enabled (bool): Flag to enable or disable user-agent filtering.
+        blocked_agents (List[str]): List of user-agent substrings to block (e.g., 'curl', 'wget').
+        excluded_paths (List[str]): List of endpoint paths where user-agent filtering should be bypassed.
+            Useful for allowing monitoring tools to access health check endpoints like '/ready' or '/healthz'.
     """
 
     enabled: bool = True
     blocked_agents: List[str] = Field(default_factory=list)
+    excluded_paths: List[str] = Field(default_factory=list)
 
 
 class PenetrationDetectionConfig(BaseModel):

--- a/pywebguard/filters/user_agent.py
+++ b/pywebguard/filters/user_agent.py
@@ -40,14 +40,15 @@ class UserAgentFilter(BaseFilter):
         Returns:
             Dict with allowed status and reason
         """
+
+        if not self.config.enabled:
+            return {"allowed": True, "reason": ""}
+
         if path in self.config.excluded_paths:
             return {
                 "allowed": True,
                 "reason": "Path excluded from user-agent filtering",
             }
-
-        if not self.config.enabled:
-            return {"allowed": True, "reason": ""}
 
         if not user_agent:
             return {"allowed": False, "reason": "Empty user agent"}
@@ -95,11 +96,14 @@ class AsyncUserAgentFilter(AsyncBaseFilter):
         Returns:
             Dict with allowed status and reason
         """
-        if path in self.config.excluded_paths:
-            return {"allowed": True, "reason": ""}
+
         if not self.config.enabled:
             return {"allowed": True, "reason": ""}
-
+        if path in self.config.excluded_paths:
+            return {
+                "allowed": True,
+                "reason": "Path excluded from user-agent filtering",
+            }
         if not user_agent:
             return {"allowed": False, "reason": "Empty user agent"}
 

--- a/pywebguard/filters/user_agent.py
+++ b/pywebguard/filters/user_agent.py
@@ -2,7 +2,7 @@
 User agent filtering functionality for PyWebGuard with both sync and async support.
 """
 
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 from pywebguard.core.config import UserAgentConfig
 from pywebguard.storage.base import BaseStorage, AsyncBaseStorage
 from pywebguard.filters.base import BaseFilter, AsyncBaseFilter
@@ -28,7 +28,9 @@ class UserAgentFilter(BaseFilter):
         self.config = config
         self.storage = storage
 
-    def is_allowed(self, user_agent: str) -> Dict[str, Union[bool, str]]:
+    def is_allowed(
+        self, user_agent: str, path: Optional[str] = None
+    ) -> Dict[str, Union[bool, str]]:
         """
         Check if a user agent is allowed.
 
@@ -38,6 +40,12 @@ class UserAgentFilter(BaseFilter):
         Returns:
             Dict with allowed status and reason
         """
+        if path in self.config.excluded_paths:
+            return {
+                "allowed": True,
+                "reason": "Path excluded from user-agent filtering",
+            }
+
         if not self.config.enabled:
             return {"allowed": True, "reason": ""}
 
@@ -75,7 +83,9 @@ class AsyncUserAgentFilter(AsyncBaseFilter):
         self.config = config
         self.storage = storage
 
-    async def is_allowed(self, user_agent: str) -> Dict[str, Union[bool, str]]:
+    async def is_allowed(
+        self, user_agent: str, path: Optional[str] = None
+    ) -> Dict[str, Union[bool, str]]:
         """
         Check if a user agent is allowed asynchronously.
 
@@ -85,6 +95,8 @@ class AsyncUserAgentFilter(AsyncBaseFilter):
         Returns:
             Dict with allowed status and reason
         """
+        if path in self.config.excluded_paths:
+            return {"allowed": True, "reason": ""}
         if not self.config.enabled:
             return {"allowed": True, "reason": ""}
 


### PR DESCRIPTION
# 🔧 Pull Request: Add support for excluded paths in UserAgentFilter logic

## 📝 Description

This PR introduces support for specifying `excluded_paths` in the `UserAgentFilter` and `AsyncUserAgentFilter` logic. Requests to these paths are exempt from user agent filtering, even if the user agent would otherwise be blocked.

---

## 📌 Changes

- Added `excluded_paths` field to `UserAgentConfig`.
- Updated `is_allowed()` logic in both sync and async filters to bypass checks for excluded paths.
- Extended unit tests (`TestUserAgentFilter` and `AsyncUserAgentFilter`) to validate this behavior.
- Updated docstrings and configuration comments to reflect new behavior.

---

## ✅ Test Coverage

- Added test cases for requests to excluded paths.
- Verified that non-excluded paths continue to respect `blocked_agents` logic.
- Confirmed behavior when filter is disabled and for empty user agents.

---

## 🚫 Blocked Agents Example

```json
{
  "enabled": true,
  "blocked_agents": ["curl", "wget", "python-requests"],
  "excluded_paths": ["/ready", "/healthz"]
}

