### PR TITLE
Include request path in user agent filtering

### DIFF
--- a/pywebguard/core/base.py
+++ b/pywebguard/core/base.py
@@ -681,7 +681,9 @@ class AsyncGuard:
             }
 
         # Check user agent filter
-        ua_result = await self.user_agent_filter.is_allowed(request_info["user_agent"])
+        ua_result = await self.user_agent_filter.is_allowed(
+            request_info["user_agent"], path=request_info["path"]
+        )
         if not ua_result["allowed"]:
             await self.logger.log_blocked_request(
                 request_info, "User agent filter", ua_result["reason"]

--- a/pywebguard/frameworks/_fastapi.py
+++ b/pywebguard/frameworks/_fastapi.py
@@ -166,7 +166,9 @@ class FastAPIGuard(BaseHTTPMiddleware):
 
         # Check user agent
         if self.guard.config.user_agent.enabled:
-            user_agent_check = await self.guard.user_agent_filter.is_allowed(user_agent)
+            user_agent_check = await self.guard.user_agent_filter.is_allowed(
+                user_agent, path=request.url.path
+            )
             if not user_agent_check["allowed"]:
                 response = await self.custom_response_handler(
                     request, user_agent_check["reason"]


### PR DESCRIPTION
# 🔧 Pull Request: Include request path in user agent filtering

## 📝 Description

This PR updates the `user_agent_check` logic to pass the request path to the `UserAgentFilter`. This enhancement allows the filter to check whether the current path is in the list of `excluded_paths` and skip user agent validation accordingly.

---

## 📌 Changes

- Modified the `is_allowed` call in the middleware to include `request.url.path`.
- Enables support for respecting `excluded_paths` defined in the `UserAgentConfig`.

---

## 🧪 Behavior Before

- User agent filtering was applied to **all** requests, regardless of the endpoint.
- Even health check or internal endpoints like `/ready` or `/healthz` were blocked if the user agent matched a blocked string.

## 🧪 Behavior After

| Path        | User Agent           | Allowed |
|-------------|----------------------|---------|
| `/ready`    | `curl/7.64.1`        | ✅ Yes  |
| `/healthz`  | `wget/1.21.3`        | ✅ Yes  |
| `/api/data` | `curl/7.64.1`        | ❌ No   |

---

## ✅ Why This Matters

This change improves operational flexibility by allowing critical endpoints (e.g., health checks, monitoring) to be accessed without being blocked by strict user agent policies. This is particularly useful in environments using CLI-based uptime or monitoring tools like `curl`, `wget`, etc.

---

Let me know if you'd like me to link this to an issue or ticket.
